### PR TITLE
fix res code to 409

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Get,
   HttpCode,
@@ -24,7 +25,7 @@ export class AuthController {
   async createUser(@Body() body: Login, @Session() session: any) {
     const user = await this.authService.signup(body);
     if (!user) {
-      throw new BadRequestException('User already exists');
+      throw new ConflictException('User already exists');
     }
     session.userId = user.id;
   }


### PR DESCRIPTION
## チケットへのリンク
[同じusernameでユーザー作成すると500が返ってくる #24](https://github.com/RIFT-tokyo/transcendence-api/issues/24)
## やったこと
仕様通り409を返すようにした
## やらないこと

## テスト
/signupに重複するusernameでPOST
## その他
