### PR TITLE
Userエンティティのcreated_at, updated_atをstringからDateに変更

### DIFF
--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -48,9 +48,9 @@ export class User {
 
   @CreateDateColumn({ type: 'timestamp with time zone' })
   @IsDate()
-  created_at: string;
+  created_at: Date;
 
   @UpdateDateColumn({ type: 'timestamp with time zone' })
   @IsDate()
-  updated_at: string;
+  updated_at: Date;
 }

--- a/src/users/users.dto.ts
+++ b/src/users/users.dto.ts
@@ -13,7 +13,7 @@ export class CreateUserDTO implements User {
 
 export class UpdateUserDTO extends PartialType(CreateUserDTO) {}
 
-export class ResponseUserDTO implements User {
+export class ResponseUserDTO {
   id: number;
   username: string;
   display_name: string;
@@ -22,8 +22,8 @@ export class ResponseUserDTO implements User {
   status_message: string;
   followers?: number;
   following?: number;
-  created_at?: string;
-  updated_at?: string;
+  created_at?: Date;
+  updated_at?: Date;
 
   constructor(user: EntityUser) {
     this.id = user.id;


### PR DESCRIPTION
## チケットへのリンク
fix #48 
## やったこと
タイトル通りUserエンティティの変更です。
ResponseUserDTOの `created_at` , `updated_at` もstringからDateに変更しています。

## やらないこと

## テスト
### 前提条件

- front側コード
  以下の32行目を削除する
https://github.com/RIFT-tokyo/transcendence-front/blob/b61283ddc672aec22c53177a021e500a37ea7422/src/App.tsx#L32

### 手順
Userが新規作成されても、問題なくcreated_at, updated_atがあることの確認です。

1. デベロッパーツールのネットワーク欄を開く
1. （ログインしている場合）ログアウトする
1. SIGN UPして新規ユーザを作成する
   - 42認証でもusername/password認証でも可
1. 作成後、ネットワーク欄で `me` が叩かれ、created_at と updated_at がISO形式の文字列であることを確認する

## その他
