### PR TITLE
Seederの修正

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/src/entities/match.entity.ts
+++ b/src/entities/match.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
@@ -19,9 +20,11 @@ export class Match {
   id: number;
 
   @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'host_player_id' })
   host_player: User;
 
   @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'guest_player_id' })
   guest_player: User;
 
   @Column({ nullable: false, default: 0 })

--- a/src/migrations/1651297724211-rename_match_user_relation.ts
+++ b/src/migrations/1651297724211-rename_match_user_relation.ts
@@ -1,0 +1,55 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class renameMatchUserRelation1651297724211
+  implements MigrationInterface
+{
+  name = 'renameMatchUserRelation1651297724211';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "match" DROP CONSTRAINT "FK_5fa2f211c458e43e6b0dd7253f7"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" DROP CONSTRAINT "FK_439f83f2637a7ea2d8bf97d9801"`,
+    );
+    await queryRunner.query(`ALTER TABLE "match" DROP COLUMN "hostPlayerId"`);
+    await queryRunner.query(`ALTER TABLE "match" DROP COLUMN "guestPlayerId"`);
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD "host_player_id" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD "guest_player_id" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD CONSTRAINT "FK_62800d9d384a3c286c0a020645c" FOREIGN KEY ("host_player_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD CONSTRAINT "FK_c6eb55846de3ffc7ddc66259898" FOREIGN KEY ("guest_player_id") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "match" DROP CONSTRAINT "FK_c6eb55846de3ffc7ddc66259898"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" DROP CONSTRAINT "FK_62800d9d384a3c286c0a020645c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" DROP COLUMN "guest_player_id"`,
+    );
+    await queryRunner.query(`ALTER TABLE "match" DROP COLUMN "host_player_id"`);
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD "guestPlayerId" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD "hostPlayerId" integer NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD CONSTRAINT "FK_439f83f2637a7ea2d8bf97d9801" FOREIGN KEY ("guestPlayerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "match" ADD CONSTRAINT "FK_5fa2f211c458e43e6b0dd7253f7" FOREIGN KEY ("hostPlayerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/seeds/AddDummyMatches.ts
+++ b/src/seeds/AddDummyMatches.ts
@@ -22,8 +22,8 @@ export class AddDummyMatches implements Seeder {
         guest_player_points = 11;
         result = 'guest';
       }
-      const host_player_id = Math.floor(Math.random() * 200) + 1;
-      const guest_player_id = Math.floor(Math.random() * 200) + 1;
+      const host_player_id = Math.floor(Math.random() * users.length) + 1;
+      const guest_player_id = Math.floor(Math.random() * users.length) + 1;
 
       matches.push({
         host_player_points,
@@ -35,7 +35,6 @@ export class AddDummyMatches implements Seeder {
         end_at: new Date(),
       });
     }
-    this.logger.log(JSON.stringify(matches));
     await connection.getRepository(Match).insert(matches);
   }
 }

--- a/src/seeds/AddDummyMatches.ts
+++ b/src/seeds/AddDummyMatches.ts
@@ -1,38 +1,41 @@
+import { Logger } from '@nestjs/common';
+import { Match } from '../entities/match.entity';
 import { Connection } from 'typeorm';
 import { Factory, Seeder } from 'typeorm-seeding';
+import { User } from '../entities/user.entity';
 
 export class AddDummyMatches implements Seeder {
+  private readonly logger = new Logger('AddDummyMatches');
+
   public async run(_: Factory, connection: Connection): Promise<any> {
     const matches = [];
-    for (let i = 0; i < 50; i++) {
+    const users = await connection.getRepository(User).find();
+
+    for (let i = 0; i < 500; i++) {
       let host_player_points = Math.floor(Math.random() * 10);
       let guest_player_points = Math.floor(Math.random() * 10);
       let result = 'draw';
-      if (host_player_points > guest_player_points) {
+      if (host_player_points >= guest_player_points) {
         host_player_points = 11;
         result = 'host';
       } else if (host_player_points < guest_player_points) {
         guest_player_points = 11;
         result = 'guest';
       }
-      const hostPlayerId = Math.floor(Math.random() * 200) + 1;
-      const guestPlayerId = Math.floor(Math.random() * 200) + 1;
+      const host_player_id = Math.floor(Math.random() * 200) + 1;
+      const guest_player_id = Math.floor(Math.random() * 200) + 1;
 
       matches.push({
         host_player_points,
         guest_player_points,
         result,
+        host_player: users.find((user) => user.id === host_player_id),
+        guest_player: users.find((user) => user.id === guest_player_id),
         start_at: new Date(),
         end_at: new Date(),
-        hostPlayerId: hostPlayerId,
-        guestPlayerId: guestPlayerId,
       });
     }
-    await connection
-      .createQueryBuilder()
-      .insert()
-      .into('match')
-      .values(matches)
-      .execute();
+    this.logger.log(JSON.stringify(matches));
+    await connection.getRepository(Match).insert(matches);
   }
 }

--- a/src/seeds/AddDummyMatches.ts
+++ b/src/seeds/AddDummyMatches.ts
@@ -3,6 +3,7 @@ import { Match } from '../entities/match.entity';
 import { Connection } from 'typeorm';
 import { Factory, Seeder } from 'typeorm-seeding';
 import { User } from '../entities/user.entity';
+import * as Faker from 'faker/locale/ja';
 
 export class AddDummyMatches implements Seeder {
   private readonly logger = new Logger('AddDummyMatches');
@@ -31,8 +32,8 @@ export class AddDummyMatches implements Seeder {
         result,
         host_player: users.find((user) => user.id === host_player_id),
         guest_player: users.find((user) => user.id === guest_player_id),
-        start_at: new Date(),
-        end_at: new Date(),
+        start_at: Faker.date.past(),
+        end_at: Faker.date.recent(),
       });
     }
     await connection.getRepository(Match).insert(matches);

--- a/src/seeds/CreateDummyUsers.ts
+++ b/src/seeds/CreateDummyUsers.ts
@@ -1,12 +1,18 @@
+import { Logger } from '@nestjs/common';
 import { Connection } from 'typeorm';
 import { Factory, Seeder } from 'typeorm-seeding';
 import User from '../factories/user.factory';
 
 export class CreateDummyUsers implements Seeder {
+  private readonly logger = new Logger('CreateDummyUsers');
   public async run(factory: Factory, connection: Connection): Promise<any> {
     const count = 500;
     const combinations = [];
-    await factory(User)().createMany(count);
+    try {
+      await factory(User)().createMany(count);
+    } catch (e) {
+      this.logger.error(e);
+    }
 
     const max_id = await connection
       .getRepository(User)
@@ -18,6 +24,9 @@ export class CreateDummyUsers implements Seeder {
     for (let i = 0; i < count * 20; i++) {
       const id1 = Math.floor(Math.random() * max_id_number) + 1;
       const id2 = Math.floor(Math.random() * max_id_number) + 1;
+      if (id1 === id2) {
+        continue;
+      }
       if (!combinations.some((c) => c.id1 === id1 && c.id2 === id2)) {
         combinations.push({ userId_1: id1, userId_2: id2 });
       }

--- a/src/seeds/CreateDummyUsers.ts
+++ b/src/seeds/CreateDummyUsers.ts
@@ -4,27 +4,30 @@ import User from '../factories/user.factory';
 
 export class CreateDummyUsers implements Seeder {
   public async run(factory: Factory, connection: Connection): Promise<any> {
-    const count = 200;
+    const count = 500;
     const combinations = [];
     await factory(User)().createMany(count);
 
+    const max_id = await connection
+      .getRepository(User)
+      .createQueryBuilder()
+      .select('MAX(id)', 'max_id')
+      .getRawOne();
+    const max_id_number = max_id.max_id;
+
     for (let i = 0; i < count * 20; i++) {
-      const id1 = Math.floor(Math.random() * count) + 1;
-      const id2 = Math.floor(Math.random() * count) + 1;
+      const id1 = Math.floor(Math.random() * max_id_number) + 1;
+      const id2 = Math.floor(Math.random() * max_id_number) + 1;
       if (!combinations.some((c) => c.id1 === id1 && c.id2 === id2)) {
-        try {
-          await connection
-            .createQueryBuilder()
-            .insert()
-            .into('user_followers_user')
-            .values({
-              userId_1: id1,
-              userId_2: id2,
-            })
-            .execute();
-          combinations.push({ id1, id2 });
-        } catch (e) {}
+        combinations.push({ userId_1: id1, userId_2: id2 });
       }
     }
+    await connection
+      .createQueryBuilder()
+      .insert()
+      .into('user_followers_user')
+      .values(combinations)
+      .orIgnore()
+      .execute();
   }
 }


### PR DESCRIPTION
## チケットへのリンク
fix 
## やったこと
Seederを修正しました。
1. ダミーユーザー追加
    - `docker compose exec api yarn seed:run -s CreateDummyUsers`
2. ダミーマッチ追加
    - `docker compose exec api yarn seed:run -s AddDummyMatches`
## やらないこと

## テスト
1. migrationの実行
    - `docker compose exec api yarn migration:run`
    - 既にDBにデータがあるとうまく動かないので、`match`テーブルのエントリーは一旦全削除してほしいです。
2. 各Seederを実行
    - 実際にSeederを実行し、エントリーが追加されていることを確認してください。
## その他
現状の実装（ページングなし）だと、これくらいのエントリーが追加されただけでも普通に重いサイトが出来上がります。
今後の検証をする上でもSeederを最低1回は実行してほしいです。
